### PR TITLE
switch from reqwest to hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ version = "0.17.4"
 [dependencies]
 clarity = "0.5"
 futures = "0.3"
+hyper = {version = "0.14", features = ["full"]}
+hyper-tls = "0.5.0"
 lazy_static = "1.4"
 log = "0.4"
 num = "0.4"
 num256 = "0.3"
-reqwest = {version = "0.11.7", features = ["json"]}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "web30"
 repository = "https://github.com/althea-net/web30"
-version = "0.17.4"
+version = "0.18"
 
 [dependencies]
 clarity = "0.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -674,3 +674,12 @@ async fn test_dai_block_response() {
     let val = val.expect("tokio failure");
     assert!(val.number > 10u32.into());
 }
+
+#[tokio::test]
+async fn test_request_timeout() {
+    // we're impatient, wait only 1 milliseconds
+    let web3 = Web3::new("https://dai.althea.net", Duration::from_millis(1));
+
+    let val = web3.xdai_get_latest_block().await;
+    assert!(val.is_err());
+}

--- a/src/jsonrpc/client.rs
+++ b/src/jsonrpc/client.rs
@@ -1,26 +1,32 @@
 use crate::jsonrpc::error::Web3Error;
-use crate::jsonrpc::request::Request;
-use crate::jsonrpc::response::Response;
+use crate::jsonrpc::request::Request as JsonRpcRequest;
+use crate::jsonrpc::response::Response as JsonResponse;
 use crate::mem::get_buffer_size;
-use reqwest::{header, Client, Method};
+use hyper::body::{Bytes, HttpBody};
+use hyper::client::HttpConnector;
+use hyper::{header, Body, Client, Method, Request};
+use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::str;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::time;
 
 pub struct HttpClient {
     id_counter: Arc<Mutex<RefCell<u64>>>,
     url: String,
-    client: Client,
+    client: Client<HttpsConnector<HttpConnector>>,
 }
 
 impl HttpClient {
     pub fn new(url: &str) -> Self {
+        let https = HttpsConnector::new();
+
         Self {
             id_counter: Arc::new(Mutex::new(RefCell::new(0u64))),
             url: url.into(),
-            client: Client::default(),
+            client: Client::builder().build(https),
         }
     }
 
@@ -30,6 +36,27 @@ impl HttpClient {
         let mut value = counter.borrow_mut();
         *value += 1;
         *value
+    }
+
+    async fn aggregate_bytes(&self, request: Request<Body>) -> Result<Bytes, Web3Error> {
+        let request_size_limit = get_buffer_size();
+        let res = self.client.request(request).await?;
+
+        trace!("response headers {:?}", res.headers());
+        trace!("using buffer size of {}", request_size_limit);
+
+        let response_size = res.size_hint().lower() as usize;
+
+        if response_size > request_size_limit {
+            return Err(Web3Error::BadResponse(format!(
+                "Size Limit {} and Response size {} Web3 Error",
+                request_size_limit, response_size
+            )));
+        }
+
+        hyper::body::to_bytes(res.into_body())
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn request_method<T: Serialize, R: 'static>(
@@ -42,35 +69,25 @@ impl HttpClient {
         for<'de> R: Deserialize<'de>,
         R: std::fmt::Debug,
     {
-        let payload = Request::new(self.next_id(), method, params);
+        let payload = JsonRpcRequest::new(self.next_id(), method, params);
+        let payload = serde_json::to_vec(&payload)?;
 
-        let res = self
-            .client
-            .request(Method::POST, &self.url)
+        let req = Request::builder()
+            .method(Method::POST)
             .header(header::CONTENT_TYPE, "application/json")
-            .timeout(timeout)
-            .json(&payload)
-            .send()
-            .await?;
+            .uri(&self.url)
+            .body(payload.into())
+            .expect("expected really body");
 
-        trace!("response headers {:?}", res.headers());
+        // race between the Timeout and the Request - with slight bias towards the request itself
+        let result: Result<Bytes, Web3Error> = tokio::select! {
+            biased;
 
-        let request_size_limit = get_buffer_size();
-        trace!("using buffer size of {}", request_size_limit);
-
-        let response_content_length = match res.content_length() {
-            Some(v) => v as usize,
-            None => request_size_limit + 1, // Just to protect ourselves from a malicious response
+            bytes = self.aggregate_bytes(req) => Ok(bytes?),
+            _ = time::sleep(timeout) => Err(Web3Error::BadResponse("Request Timed Out".into()))
         };
 
-        if response_content_length > request_size_limit {
-            return Err(Web3Error::BadResponse(format!(
-                "Size Limit {} Web3 Error",
-                request_size_limit
-            )));
-        }
-
-        let data: Response<R> = res.json().await?;
+        let data: JsonResponse<R> = serde_json::from_slice(&result?)?;
         trace!("got web3 response {:#?}", data);
 
         Ok(data.result)

--- a/src/jsonrpc/client.rs
+++ b/src/jsonrpc/client.rs
@@ -77,7 +77,7 @@ impl HttpClient {
             .header(header::CONTENT_TYPE, "application/json")
             .uri(&self.url)
             .body(payload.into())
-            .expect("expected really body");
+            .expect("Expected json body");
 
         // race between the Timeout and the Request - with slight bias towards the request itself
         let result: Result<Bytes, Web3Error> = tokio::select! {

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -11,7 +11,7 @@ use tokio::time::error::Elapsed;
 #[derive(Debug)]
 pub enum Web3Error {
     BadResponse(String),
-    JsonRpcError(reqwest::Error),
+    JsonRpcError(hyper::Error),
     InsufficientGas {
         balance: Uint256,
         base_gas: Uint256,
@@ -46,8 +46,8 @@ impl From<Elapsed> for Web3Error {
     }
 }
 
-impl From<reqwest::Error> for Web3Error {
-    fn from(error: reqwest::Error) -> Self {
+impl From<hyper::Error> for Web3Error {
+    fn from(error: hyper::Error) -> Self {
         Web3Error::JsonRpcError(error)
     }
 }


### PR DESCRIPTION
in order to correctly check the response size of the request
this PR introduces hyper instead of reqwest for more lower level handling of requests
and more control of the stream of bytes from the response 
(basically we can check the size of response after each stream of bytes)
but for now I just used
```
let response_size = res.size_hint().lower() as usize;
```

that should suffice