### PR TITLE
update deps and clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/onomyprotocol/web30.git"
 version = "0.18.3"
 
 [dependencies]
-clarity = { git = "https://github.com/onomyprotocol/clarity.git", rev = "0b69d4aabae546a2d1bd296f04ba64a8a1546b9a" }
+clarity = { git = "https://github.com/AaronKutch/clarity.git", rev = "e3edd1e9d11767d1f23cfdcccaec240d4d11832d" }
 hyper = { version = "0.14", features = ["full"] }
 hyper-tls = "0.5.0"
 lazy_static = "1.4"
@@ -17,7 +17,7 @@ num = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "1.17", features = ["macros", "time"] }
+tokio = { version = "1.20", features = ["macros", "time"] }
 u64_array_bigints = { version = "0.3", default-features = false, features = ["serde_support"] }
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -847,5 +847,5 @@ async fn test_request_timeout() {
     let web3 = Web3::new("https://dai.althea.net", Duration::from_millis(1));
 
     let val = web3.xdai_get_latest_block().await;
-    assert!(val.is_err());
+    val.unwrap_err();
 }

--- a/src/event_utils.rs
+++ b/src/event_utils.rs
@@ -164,7 +164,7 @@ impl Web3 {
             topics: Some(final_topics),
         };
 
-        Ok(self.eth_get_logs(new_filter).await.unwrap())
+        self.eth_get_logs(new_filter).await
     }
 
     /// Checks for multiple events as defined by arbitrary user input over a block range. If no ending block is provided
@@ -202,6 +202,6 @@ impl Web3 {
             topics: Some(final_topics),
         };
 
-        Ok(self.eth_get_logs(new_filter).await.unwrap())
+        self.eth_get_logs(new_filter).await
     }
 }


### PR DESCRIPTION
In a recent commit you put an `unwrap` on `eth_get_logs` to fix an earlier version of a lint, I changed it to propagate any errors